### PR TITLE
Fix region creation block breaking bug

### DIFF
--- a/src/main/java/com/allfire/eregions/listeners/PlayerChatListener.java
+++ b/src/main/java/com/allfire/eregions/listeners/PlayerChatListener.java
@@ -97,8 +97,8 @@ public class PlayerChatListener implements Listener {
                 
                 plugin.getMessageUtils().sendMessage(player, "&aРегион &e" + regionName + " &aуспешно создан!");
                 
-                // Remove from waiting for name but keep selection for size/move commands
-                selectionManager.removeWaitingForName(player);
+                // Clear selection completely after successful region creation
+                selectionManager.clearSelection(player);
             } else {
                 // Check if it's due to overlapping regions
                 List<String> overlappingRegions = plugin.getWorldGuardUtils().getOverlappingRegions(


### PR DESCRIPTION
Clear player selection after successful region creation to fix Shift-breaking being blocked.

Previously, after a region was created via `/erg create`, the player's selection was not fully cleared. This caused the system to remain in a "selection mode," which, due to a check in `PlayerInteractListener`, prevented players from breaking blocks while holding Shift until `/erg cancel` was manually entered. This change ensures the selection is cleared immediately.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea2e4c92-3a09-4944-b5e0-9cd068db8e06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ea2e4c92-3a09-4944-b5e0-9cd068db8e06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

